### PR TITLE
Rule 4: Any dead cell with exactly three live neighbors becomes a live cell.

### DIFF
--- a/lib/conway.rb
+++ b/lib/conway.rb
@@ -18,7 +18,7 @@ class Conway
     for i in 0..(state.length-1) do
       for ii in 0..(state[i].length-1) do
         living_neighbors = living_neighbors_count(state, i, ii)
-        if (living_neighbors >= 2 && living_neighbors <= 3)
+        if (state[i][ii] == 1 && living_neighbors >= 2 && living_neighbors <= 3) || (state[i][ii] == 0 && living_neighbors == 3)
           next_state[i][ii] = 1
         end
       end

--- a/lib/conway.rb
+++ b/lib/conway.rb
@@ -17,10 +17,7 @@ class Conway
 
     for i in 0..(state.length-1) do
       for ii in 0..(state[i].length-1) do
-        outer_index = i == 0 ? 0 : i - 1
-        inner_index = ii == 0 ? 0 : ii - 1
-        neighbors = state[outer_index..i+1].map { |inner| inner[inner_index..ii+1]}
-        living_neighbors = neighbors.flatten.reject {|x| x!=1}.count - 1
+        living_neighbors = living_neighbors_count(state, i, ii)
         if (living_neighbors >= 2 && living_neighbors <= 3)
           next_state[i][ii] = 1
         end
@@ -28,5 +25,13 @@ class Conway
     end
 
     Conway.new({state: next_state})
+  end
+
+  def living_neighbors_count(grid, i, ii)
+    cell_value = grid[i][ii]
+    outer_index = i == 0 ? 0 : i - 1
+    inner_index = ii == 0 ? 0 : ii - 1
+    neighbors = grid[outer_index..i+1].map { |inner| inner[inner_index..ii+1]}
+    neighbors.flatten.reject {|x| x!=1}.count - cell_value
   end
 end

--- a/spec/conway_spec.rb
+++ b/spec/conway_spec.rb
@@ -26,6 +26,18 @@ describe Conway do
       conway = Conway.new({state: input_state})
       expect(conway.next.state[0][0]).to eq(0)
     end
+    it 'should not regenerate dead cell (1,1) with four adjacent live neighbors' do
+      input_state = [
+        [1,0,1,0,0,0,0,0],
+        [0,0,0,0,0,0,0,0],
+        [1,0,1,0,0,0,0,0],
+        [0,0,0,0,0,0,0,0],
+        [0,0,0,0,0,0,0,0],
+        [0,0,0,0,0,0,0,0]
+      ]
+      conway = Conway.new({state: input_state})
+      expect(conway.next.state[1][1]).to eq(0)
+    end
   end
   context 'Rule 2: Overcrowding' do
     it 'should not propagate a living cell (1,1) with more than 3 neighbors' do

--- a/spec/conway_spec.rb
+++ b/spec/conway_spec.rb
@@ -38,6 +38,18 @@ describe Conway do
       conway = Conway.new({state: input_state})
       expect(conway.next.state[1][1]).to eq(0)
     end
+    it 'should not regenerate dead cell (1,1) with two adjacent live neighbors' do
+      input_state = [
+        [0,0,1,0,0,0,0,0],
+        [0,0,0,0,0,0,0,0],
+        [1,0,0,0,0,0,0,0],
+        [0,0,0,0,0,0,0,0],
+        [0,0,0,0,0,0,0,0],
+        [0,0,0,0,0,0,0,0]
+      ]
+      conway = Conway.new({state: input_state})
+      expect(conway.next.state[1][1]).to eq(0)
+    end
   end
   context 'Rule 2: Overcrowding' do
     it 'should not propagate a living cell (1,1) with more than 3 neighbors' do
@@ -107,6 +119,23 @@ describe Conway do
       ]
       conway = Conway.new({state: input_state})
       expect(conway.next.state[1][1]).to eq(1)
+    end
+  end
+  context 'Rule 4: Regeneration' do
+    it 'should regenerate dead cells [(0,1),(1,0),(1,2),(2,1)] with exactly 3 neighbors' do
+      input_state = [
+        [1,0,1,0,0,0,0,0],
+        [0,1,0,0,0,0,0,0],
+        [1,0,1,0,0,0,0,0],
+        [0,0,0,0,0,0,0,0],
+        [0,0,0,0,0,0,0,0],
+        [0,0,0,0,0,0,0,0]
+      ]
+      conway = Conway.new({state: input_state})
+      expect(conway.next.state[0][1]).to eq(1)
+      expect(conway.next.state[1][0]).to eq(1)
+      expect(conway.next.state[1][2]).to eq(1)
+      expect(conway.next.state[2][1]).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Stop dead cells with 4 live neighbors from regenerating and refactor some related code into a method.